### PR TITLE
Fix: responsive css & maintain focus on text input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,81 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![cover](./cover.jpg)
 
-Chat bubble tool for YouTube
-============================
+# Chat bubble tool for YouTube
 
 A tool for recording typing animations and sounds with imitated chat UI.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "prettier": "prettier -c .",
+    "prettier-fix": "prettier -w ."
   },
   "dependencies": {
     "framer-motion": "^6.2.8",

--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,4 @@
 .App {
-  background-color: #00a000;
   width: 100vw;
   height: 100vh;
   display: flex;

--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 .App {
   background-color: #00a000;
-  width: 1920px;
-  height: 1080px;
+  width: 100vw;
+  height: 100vh;
   display: flex;
   flex-direction: column-reverse;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback } from 'react'
 import './App.css'
 import Chat from './chat'
 import Bubble from './bubble'
@@ -17,19 +17,12 @@ function App() {
     }
   }, [newMessage, messages])
 
-  useEffect(() => {
-    const el = document.querySelector('.bubble.input > div')
-    if (el) {
-      el.focus()
-    }
-  }, [])
-
   return (
     <div className="App">
       <Chat>
         <AnimatePresence>
           {messages.map((m, index) => (
-            <Bubble key={index} id={m}>
+            <Bubble key={`${index}-${m}`} id={m}>
               {m}
             </Bubble>
           ))}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,10 @@
-import { useState, useCallback, useEffect } from 'react'
+import {useState, useCallback, useEffect} from 'react'
 import './App.css'
 import Chat from './chat'
 import Bubble from './bubble'
 import BubbleInput from './bubble-input'
 import useMessages from './use-messages'
-import { motion, AnimatePresence } from 'framer-motion'
+import {AnimatePresence} from 'framer-motion'
 
 function App() {
   const [messages, addMessage] = useMessages([])
@@ -28,8 +28,8 @@ function App() {
     <div className="App">
       <Chat>
         <AnimatePresence>
-          {messages.map(m => (
-            <Bubble key={m} id={m}>
+          {messages.map((m, index) => (
+            <Bubble key={index} id={m}>
               {m}
             </Bubble>
           ))}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,10 @@
-import {useState, useCallback, useEffect} from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import './App.css'
 import Chat from './chat'
 import Bubble from './bubble'
 import BubbleInput from './bubble-input'
 import useMessages from './use-messages'
-import {AnimatePresence} from 'framer-motion'
+import { AnimatePresence } from 'framer-motion'
 
 function App() {
   const [messages, addMessage] = useMessages([])

--- a/src/bubble-input.css
+++ b/src/bubble-input.css
@@ -14,7 +14,7 @@
 .bubble.input > div {
   border: none;
   outline: none;
-  background-color: #eee;
-  font-size: 32px;
+  background-color: #eeeeee;
+  font-size: 2rem;
   min-width: 30px;
 }

--- a/src/bubble-input.jsx
+++ b/src/bubble-input.jsx
@@ -11,6 +11,7 @@ const BubbleInput = ({ onChange, onSubmit, value }) => {
     },
     [onChange]
   )
+
   const handleKeyDown = useCallback(
     e => {
       if (e.keyCode === 13) {
@@ -18,14 +19,13 @@ const BubbleInput = ({ onChange, onSubmit, value }) => {
         e.preventDefault()
         setSubmitted(true)
         setTimeout(() => {
-          window.document.querySelector('.bubble.input > div').focus()
           setSubmitted(false)
         }, 10)
       }
     },
     [onSubmit]
   )
-  console.log('value:', value)
+
   return (
     <div
       className={`bubble input ${value.length === 0 ? 'empty' : ''} ${

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -1,15 +1,17 @@
 .bubble {
   border-radius: 30px;
   padding: 12px 20px;
-  margin-top: 5px;
-  margin-bottom: 5px;
   display: inline-block;
   max-width: 600px;
 }
 
+.bubble:not(:first-of-type) {
+  margin-top: 10px;
+}
+
 .bubble {
   margin-right: 25%;
-  background-color: #eee;
+  background-color: #eeeeee;
   position: relative;
 }
 
@@ -22,7 +24,7 @@
   left: -12px;
   height: 26px;
   width: 30px;
-  background: #eee;
+  background: #eeeeee;
   border-bottom-right-radius: 20px;
 }
 

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -3,6 +3,7 @@
   padding: 12px 20px;
   display: inline-block;
   max-width: 600px;
+  overflow-wrap: break-word;
 }
 
 .bubble:not(:first-of-type) {
@@ -10,7 +11,6 @@
 }
 
 .bubble {
-  margin-right: 25%;
   background-color: #eeeeee;
   position: relative;
 }

--- a/src/bubble.jsx
+++ b/src/bubble.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { motion } from 'framer-motion'
 import './bubble.css'
 
-const Bubble = ({ id, children, sender }) => {
+const Bubble = ({ id, children }) => {
   return (
     <motion.div
       key={id}

--- a/src/chat.css
+++ b/src/chat.css
@@ -6,5 +6,5 @@
   flex-flow: column wrap;
   align-items: flex-start;
 
-  font-size: 32px;
+  font-size: 2rem;
 }

--- a/src/content-editable.jsx
+++ b/src/content-editable.jsx
@@ -27,7 +27,7 @@ class ContentEditable extends React.Component {
 
   emitChange = () => {
     const { current: div } = this.refElement
-    var value = div.innerText
+    let value = div.innerText
     if (this.props.onChange && value !== this.lastValue) {
       this.props.onChange({
         target: {

--- a/src/content-editable.jsx
+++ b/src/content-editable.jsx
@@ -3,31 +3,45 @@ import * as React from 'react'
 class ContentEditable extends React.Component {
   constructor(props) {
     super(props)
+
     this.refElement = React.createRef()
   }
+
   render() {
     return (
       <div
-        key={Math.random()}
         ref={this.refElement}
         onInput={this.emitChange}
-        onBlur={this.emitChange}
+        onBlur={this.onBlur}
         onKeyDown={this.emitKeyDown}
         contentEditable
         spellCheck="false"
-        dangerouslySetInnerHTML={{ __html: this.props.value }}
       ></div>
     )
   }
 
   shouldComponentUpdate(nextProps) {
     const { current: div } = this.refElement
-    return nextProps.value !== div.innerText
+
+    return nextProps.value !== div.textContent
+  }
+
+  componentDidUpdate() {
+    const { current: div } = this.refElement
+
+    if (div.textContent !== this.props.value) {
+      div.textContent = this.props.value
+    }
+  }
+
+  componentDidMount() {
+    this.focus()
   }
 
   emitChange = () => {
     const { current: div } = this.refElement
-    let value = div.innerText
+    const value = div.textContent
+
     if (this.props.onChange && value !== this.lastValue) {
       this.props.onChange({
         target: {
@@ -35,12 +49,23 @@ class ContentEditable extends React.Component {
         }
       })
     }
+
     this.lastValue = value
   }
 
   emitKeyDown = e => {
     const { onKeyDown } = this.props
     onKeyDown && onKeyDown(e)
+  }
+
+  focus = () => {
+    setTimeout(() => {
+      this.refElement.current.focus()
+    }, 0)
+  }
+
+  onBlur = () => {
+    this.focus()
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: black;
+  background-color: #00a000;
 }
 
 code {

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,3 @@
-html,
-body,
-#root {
-  width: 100%;
-  height: 100%;
-}
-
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
- Prevented page overflowing on resolutions <=1080p, by setting `width: 100vh; height: 100vh` on  `.app`.
- Replaced `px` with `rem` when setting font-sizes to ensure responsiveness.
- Made sure to always maintain focus on the text input. One example of where it lost focus was when we clicked on any area of the page other than the text input, making it hard to use the application, since the text input is small and invisible.